### PR TITLE
Fix sidebar actions by including %SystemRoot% in subprocess env parameter

### DIFF
--- a/sidebar.py
+++ b/sidebar.py
@@ -46,7 +46,16 @@ class CommandThread(threading.Thread):
         envPATH = envPATH + os.pathsep + s.get('node_dir')
       if s.get('npm_dir') and envPATH.find(s.get('npm_dir')) == -1:
         envPATH = envPATH + os.pathsep + s.get('npm_dir')
-      p = subprocess.Popen(self.command, cwd=self.working_dir, env={'PATH': envPATH}, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1, startupinfo=si)
+
+      # https://docs.python.org/2/library/subprocess.html
+      # Note If specified, env must provide any variables required for the program to execute. 
+      # On Windows, in order to run a side-by-side assembly the specified env **must** include a valid SystemRoot.
+      envObj = {
+        'PATH': envPATH,
+        'SYSTEMROOT': os.environ['SYSTEMROOT']
+      }
+      
+      p = subprocess.Popen(self.command, cwd=self.working_dir, env=envObj, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1, startupinfo=si)
       for line in iter(p.stdout.readline, b''):
         line2 = line.decode().strip('\r\n')
         # only show output for mocha     


### PR DESCRIPTION
According to [this](https://docs.python.org/2/library/subprocess.html) documentation:

> **Note** If specified, *env* must provide any variables required for the program to execute. On Windows, in order to run a side-by-side assembly the specified *env* **must** include a valid `SystemRoot`.

This PR fixes the Sublime sidebar actions not working, but avoids passing `None` to the subprocess env in order to maintain any user provided settings.

* This is tested and working on Win10 Pro x64. 
* No expected issues with Windows operating systems. 
* *May* cause some undesirable behaviour on platforms with differing `os.environ['SYSTEMROOT']`